### PR TITLE
Script to download dataset

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,5 @@
+.Rproj
+.Rproj.user
+.Rhistory
+.RData
+.Ruserdata

--- a/src/get_data.R
+++ b/src/get_data.R
@@ -1,0 +1,28 @@
+# author: Ryan Homer
+# date: 2020-01-18
+#
+"Fetch a dataset to a specified path.
+
+Usage: get_dataset.R --url=<URL to the dataset> --destfile=<local file path> [--quiet]
+
+Options:
+<url>      Complete URL to the dataset.
+<destfile> The destination path, including the filename.
+<quiet>    Suppress output.
+" -> doc
+
+library(docopt)
+suppressMessages(library(RCurl))
+
+main <- function(opt) {
+  # if we make it here, we are guaranteed by docopt to have `url`, `destfile` and `quiet` args,
+  # so no need to use `is.null`
+  if (!url.exists(opt$url)) {
+    stop("Unable to access URL!")
+  }
+
+  download.file(opt$url, destfile = opt$destfile, quiet = opt$quiet)
+}
+
+opt <-docopt(doc)
+main(opt)

--- a/src/get_kaggle_dataset.R
+++ b/src/get_kaggle_dataset.R
@@ -1,0 +1,46 @@
+# author: Ryan Homer
+# date: 2020-01-16
+#
+"Fetch a Kaggle dataset to a specified path.
+
+If you have a `kaggle.json` authentication file, you do not need to specify `username` or `key`.
+
+Usage: get_kaggle_dataset.R [--username=<Kaggle username> --key=<Kaggle API key>] --dataset=<dataset> [--unzip --force] <path>
+
+Options:
+<username>    Your Kaggle username.
+<key>         Your Kaggle API key
+<dataset>     The Kaggle dataset name (in the form `account_name/dataset_name`)
+<path>        The path of the destination folder
+<unzip>       Unzip archive (deletes archive after extraction)
+<force>       Skip check whether local version of file is up to date, force file download
+" -> doc
+
+library(docopt)
+
+main <- function(opt) {
+  if (!is.null(opt$username) && !is.null(opt$key)) {
+    Sys.setenv(KAGGLE_USERNAME = opt$username,
+               KAGGLE_KEY = opt$key)
+
+    print(Sys.getenv("KAGGLE_USERNAME"))
+    print(Sys.getenv("KAGGLE_KEY"))
+  }
+
+  # Prepare system command and execute
+  command <- "kaggle datasets download"
+  if (!is.null(opt$unzip)) {
+    command <- paste(command, "--unzip")
+  }
+  if (!is.null(opt$force)) {
+    command <- paste(command, "--force")
+  }
+  if (!is.null(opt$path)) {
+    command <- paste(command, "-p", opt$path)
+  }
+  command <- paste(command, opt$dataset)
+  system(command)
+}
+
+opt <-docopt(doc)
+main(opt)


### PR DESCRIPTION
Notes:
* The dataset is now hosted here: https://github.com/ryanhomer/dsci522-group411-data
* I've included two scripts
  - **get_data.R**: This is the script we'll use to download data from the repo stated above
  - **get_kaggle_dataset.R**: This is the script that can be used to download directly from Kaggle. Even though we won't be using this at the moment, I'm including it in case we need it later on.

This is an example of how to use the script. Assuming you are in the project root directory in a terminal session:

    Rscript src/get_data.R --url=https://raw.githubusercontent.com/ryanhomer/dsci522-group411-data/master/avocado.csv --destfile=data/avocado.csv

I have not written any documentation as yet. I will wait until we know better how we are expected to use the script in our workflow.